### PR TITLE
added etc dir to Hilary package

### DIFF
--- a/lib/package/util.js
+++ b/lib/package/util.js
@@ -68,6 +68,7 @@ var copyHilaryReleaseFiles = module.exports.copyHilaryReleaseFiles = function(de
     // package. If you change this, ensure you test "link" content items have previews generated properly on the resulting
     // distribution.
     CoreUtil.exec('cp -RLf node_modules ' + srcDir);
+    CoreUtil.exec('cp -RLf etc ' + srcDir);
 
     // Remove all orig and rej files as they are useless and can trip up the debian packaging process
     CoreUtil.exec('find ' + srcDir + ' -name "*.orig" -exec rm {} \\;');


### PR DESCRIPTION
I did not see a sensible way of only including release/migration scripts for that release so for the moment I have added all of etc. It's quite small anyway.
